### PR TITLE
Correction for uninstall

### DIFF
--- a/twitter-user-timelines/trunk/uninstall.php
+++ b/twitter-user-timelines/trunk/uninstall.php
@@ -3,7 +3,7 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
-
+global $wpdb;
 // Delete all transients we created
 $sql = "SELECT `option_name` AS `name`, `option_value` AS `value`
         FROM  $wpdb->options


### PR DESCRIPTION
If the variable global is not indicate it cause a crash on uninstall Wordpress 4.5.1